### PR TITLE
Add a `B2Dataset` explicit wrapper

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,11 @@ You may instead just ``import b2h5py`` and explicitly enable the optimization gl
     with b2h5py.fast_slicing():
         # ... code that will use Blosc2 optimized slicing ...
 
+Finally, you may explicitly enable optimizations for a given h5py dataset by wrapping it in a `B2Dataset` instance::
+
+    b2dset = b2h5py.B2Dataset(dset)
+    # ... slicing ``b2dset`` will use Blosc2 optimization ...
+
 Building
 --------
 

--- a/b2h5py/__init__.py
+++ b/b2h5py/__init__.py
@@ -11,17 +11,21 @@ Then `disable_fast_slicing()` may be called to disable them again (by undoing
 the patching).  As an alternative, you may also activate optimizations
 temporarily using `fast_slicing()` to get a context manager.
 
+To explicitly enable optimizations for a given h5py Dataset, use `B2Dataset`.
+
 **Note:** For testing and debugging purposes, you may force-disable
 optimizations at any time by setting ``BLOSC2_FILTER=1`` in the environment.
 """
 
+from .blosc2 import B2Dataset
 from .patch import (disable_fast_slicing,
                     enable_fast_slicing,
                     fast_slicing,
                     is_fast_slicing_enabled)
 
 
-__all__ = ['disable_fast_slicing',
+__all__ = ['B2Dataset',
+           'disable_fast_slicing',
            'enable_fast_slicing',
            'fast_slicing',
            'is_fast_slicing_enabled']

--- a/b2h5py/__init__.py
+++ b/b2h5py/__init__.py
@@ -11,7 +11,8 @@ Then `disable_fast_slicing()` may be called to disable them again (by undoing
 the patching).  As an alternative, you may also activate optimizations
 temporarily using `fast_slicing()` to get a context manager.
 
-To explicitly enable optimizations for a given h5py Dataset, use `B2Dataset`.
+To explicitly enable optimizations for a given h5py ``Dataset`` instance, use
+`B2Dataset`.
 
 **Note:** For testing and debugging purposes, you may force-disable
 optimizations at any time by setting ``BLOSC2_FILTER=1`` in the environment.

--- a/b2h5py/blosc2.py
+++ b/b2h5py/blosc2.py
@@ -231,8 +231,8 @@ class B2Dataset:
         return self.__dataset
 
     @property
-    def is_b2_fast_access(self) -> bool:
-        """Whether or not Blosc2 fast slicing access is enabled"""
+    def is_b2_fast_slicing(self) -> bool:
+        """Whether or not Blosc2 optimized slicing is enabled"""
         return getattr(self, opt_dataset_ok_prop)
 
     def __getitem__(self, args):

--- a/b2h5py/blosc2.py
+++ b/b2h5py/blosc2.py
@@ -245,4 +245,4 @@ class B2Dataset:
             return opt_selection_read(self.__dataset, selection)
 
     def __getattr__(self, name):  # Proxy h5py.Dataset methods and attributes
-        return getattr(self.dataset, name)
+        return getattr(self.__dataset, name)

--- a/b2h5py/tests/common.py
+++ b/b2h5py/tests/common.py
@@ -40,7 +40,10 @@ def checking_opt_slicing():
 
 
 def check_opt_slicing(test):
-    """Decorate `test` to fail if slicing did not use expected optimization"""
+    """Decorate `test` to fail if slicing did not use expected optimization.
+
+    It requires a `should_enable_opt() -> bool` method in the test case.
+    """
     @functools.wraps(test)
     def checked_test(self):
         if not self.should_enable_opt():

--- a/b2h5py/tests/common.py
+++ b/b2h5py/tests/common.py
@@ -1,0 +1,46 @@
+"""Common code for b2h5py tests."""
+
+import functools
+
+import b2h5py
+import h5py
+import hdf5plugin as h5p
+
+
+class Blosc2OptNotUsedError(Exception):
+    """Blosc2 optimization was not used by unit test"""
+    pass
+
+
+class StoreArrayMixin:
+    # Requires: self.f (read/write), self.arr, self.chunks
+    # Provides: self.f (read-only), self.dset
+    def setUp(self):
+        comp = h5p.Blosc2(cname='lz4', clevel=5, filters=h5p.Blosc2.SHUFFLE)
+        self.f.create_dataset('x', data=self.arr, chunks=self.chunks, **comp)
+
+        # Reopen the test file read-only to ensure
+        # that no HDF5/h5py caching takes place.
+        fn = self.f.filename
+        self.f.close()
+        self.f = h5py.File(fn, 'r')
+        self.dset = self.f['x']
+
+
+def check_opt_slicing(test):
+    """Decorate `test` to fail if slicing did not use expected optimization"""
+    @functools.wraps(test)
+    def checked_test(self):
+        if not self.should_enable_opt():
+            return test(self)
+        # If the dataset class is not patched,
+        # the exception set below is never raised anyway.
+        self.assertTrue(b2h5py.is_fast_slicing_enabled())
+        # Force an exception if the optimization is not used.
+        orig_exc = b2h5py.blosc2._no_opt_error
+        b2h5py.blosc2._no_opt_error = Blosc2OptNotUsedError
+        try:
+            return test(self)
+        finally:
+            b2h5py.blosc2._no_opt_error = orig_exc
+    return checked_test

--- a/b2h5py/tests/test_b2dataset.py
+++ b/b2h5py/tests/test_b2dataset.py
@@ -1,4 +1,4 @@
-"""Test using B2Dataset to enable fast access to Blosc2 compressed dataset.
+"""Test using B2Dataset to enable optimized access to Blosc2 compressed dataset.
 """
 
 import numpy as np
@@ -21,7 +21,7 @@ class TestB2Dataset(TestCase, StoreArrayMixin):
 
     def testB2Dataset(self):
         b2dataset = B2Dataset(self.dset)
-        self.assertTrue(b2dataset.is_b2_fast_access)
+        self.assertTrue(b2dataset.is_b2_fast_slicing)
 
         # Access h5py.Dataset attribute
         self.assertEqual(b2dataset.chunks, self.dset.chunks)
@@ -38,7 +38,7 @@ class TestB2Dataset(TestCase, StoreArrayMixin):
     def testIter(self):
         """Iteration does not hang"""
         b2dataset = B2Dataset(self.dset)
-        self.assertTrue(b2dataset.is_b2_fast_access)
+        self.assertTrue(b2dataset.is_b2_fast_slicing)
 
         b2dsiter = iter(b2dataset)
         next(b2dsiter)

--- a/b2h5py/tests/test_b2dataset.py
+++ b/b2h5py/tests/test_b2dataset.py
@@ -34,3 +34,13 @@ class TestB2Dataset(TestCase, StoreArrayMixin):
             with checking_opt_slicing():
                 b2dataset[::2]  # step != 1 not supported currently
         self.assertArrayEqual(b2dataset[::2], self.arr[::2])
+
+    def testIter(self):
+        """Iteration does not hang"""
+        b2dataset = B2Dataset(self.dset)
+        self.assertTrue(b2dataset.is_b2_fast_access)
+
+        b2dsiter = iter(b2dataset)
+        next(b2dsiter)
+        next(b2dsiter)
+        return

--- a/b2h5py/tests/test_b2dataset.py
+++ b/b2h5py/tests/test_b2dataset.py
@@ -1,43 +1,30 @@
 """Test using B2Dataset to enable fast access to Blosc2 compressed dataset.
 """
 
-import h5py
-import hdf5plugin
 import numpy as np
 
 from b2h5py import B2Dataset
+from b2h5py.tests.common import StoreArrayMixin
 from h5py.tests.common import TestCase
 
 
-class TestB2Dataset(TestCase):
+class TestB2Dataset(TestCase, StoreArrayMixin):
     def setUp(self):
-        super().setUp()
+        TestCase.setUp(self)
 
         shape = 3500, 300
-        chunks = 1747, 150
-        self.data = np.arange(np.prod(shape), dtype="u2").reshape(shape)
-
-        compression = hdf5plugin.Blosc2(cname='lz4', clevel=5, filters=hdf5plugin.Blosc2.SHUFFLE)
-        self.f.create_dataset('data', data=self.data, chunks=chunks, **compression)
-
-        filename = self.f.filename
-        self.f.close()
-        self.f = h5py.File(filename, "r")
-        self.h5dataset = self.f["data"]
-
-    def tearDown(self):
-        self.h5dataset = None
-        super().tearDown()
+        self.chunks = 1747, 150
+        self.arr = np.arange(np.prod(shape), dtype="u2").reshape(shape)
+        StoreArrayMixin.setUp(self)
 
     def testB2Dataset(self):
-        b2dataset = B2Dataset(self.h5dataset)
+        b2dataset = B2Dataset(self.dset)
         self.assertTrue(b2dataset.is_b2_fast_access)
 
         # Access h5py.Dataset attribute
-        self.assertEqual(b2dataset.chunks, self.h5dataset.chunks)
+        self.assertEqual(b2dataset.chunks, self.dset.chunks)
 
         # Access whole array
-        self.assertArrayEqual(b2dataset[()], self.data)
+        self.assertArrayEqual(b2dataset[()], self.arr)
         # Unoptimized access
-        self.assertArrayEqual(b2dataset[::2], self.data[::2])
-
+        self.assertArrayEqual(b2dataset[::2], self.arr[::2])

--- a/b2h5py/tests/test_b2dataset.py
+++ b/b2h5py/tests/test_b2dataset.py
@@ -1,37 +1,47 @@
 """Test using B2Dataset to enable fast access to Blosc2 compressed dataset.
 """
 
+import os.path
+import tempfile
+from unittest import TestCase
+
 import h5py
 import hdf5plugin
 import numpy as np
-import pytest
 
 from b2h5py import B2Dataset
 
 
-@pytest.fixture
-def hdf5_test_dataset(tmp_path):
-    """Text fixture creating a hdf5 file with a "data" dataset compression with Blosc2"""
-    shape = 3500, 300
-    chunks = 1747, 150
-    data = np.arange(np.prod(shape), dtype="u2").reshape(shape)
+class TestB2Dataset(TestCase):
+    def setUp(self):
+        shape = 3500, 300
+        chunks = 1747, 150
+        self.data = np.arange(np.prod(shape), dtype="u2").reshape(shape)
 
-    with h5py.File(tmp_path / "test_file.h5", "w") as f:
-        compression = hdf5plugin.Blosc2(cname='lz4', clevel=5, filters=hdf5plugin.Blosc2.SHUFFLE)
-        f.create_dataset('data', data=data, chunks=chunks, **compression)
+        self.tempdir = tempfile.TemporaryDirectory()
+        filename = os.path.join(self.tempdir.name, "test_file.h5")
 
-    with h5py.File(tmp_path / "test_file.h5", "r") as f:
-        yield f["data"]
+        with h5py.File(filename, "w") as f:
+            compression = hdf5plugin.Blosc2(cname='lz4', clevel=5, filters=hdf5plugin.Blosc2.SHUFFLE)
+            f.create_dataset('data', data=self.data, chunks=chunks, **compression)
 
+        self.h5file = h5py.File(filename, "r")
+        self.h5dataset = self.h5file["data"]
 
-def test_B2Dataset(hdf5_test_dataset):
-    b2dataset = B2Dataset(hdf5_test_dataset)
-    assert b2dataset.is_b2_fast_access
+    def tearDown(self):
+        self.h5dataset = None
+        self.h5file.close()
+        self.tempdir.cleanup()
 
-    # Access h5py.Dataset attribute
-    assert b2dataset.chunks == hdf5_test_dataset.chunks
+    def testB2Dataset(self):
+        b2dataset = B2Dataset(self.h5dataset)
+        self.assertTrue(b2dataset.is_b2_fast_access)
 
-    # Access whole array
-    assert np.array_equal(b2dataset[()], hdf5_test_dataset[()])
-    # Unoptimized access
-    assert np.array_equal(b2dataset[::2], hdf5_test_dataset[::2])
+        # Access h5py.Dataset attribute
+        self.assertEqual(b2dataset.chunks, self.h5dataset.chunks)
+
+        # Access whole array
+        self.assertTrue(np.array_equal(b2dataset[()], self.data))
+        # Unoptimized access
+        self.assertTrue(np.array_equal(b2dataset[::2], self.data[::2]))
+

--- a/b2h5py/tests/test_b2dataset.py
+++ b/b2h5py/tests/test_b2dataset.py
@@ -1,37 +1,33 @@
 """Test using B2Dataset to enable fast access to Blosc2 compressed dataset.
 """
 
-import os.path
-import tempfile
-from unittest import TestCase
-
 import h5py
 import hdf5plugin
 import numpy as np
 
 from b2h5py import B2Dataset
+from h5py.tests.common import TestCase
 
 
 class TestB2Dataset(TestCase):
     def setUp(self):
+        super().setUp()
+
         shape = 3500, 300
         chunks = 1747, 150
         self.data = np.arange(np.prod(shape), dtype="u2").reshape(shape)
 
-        self.tempdir = tempfile.TemporaryDirectory()
-        filename = os.path.join(self.tempdir.name, "test_file.h5")
+        compression = hdf5plugin.Blosc2(cname='lz4', clevel=5, filters=hdf5plugin.Blosc2.SHUFFLE)
+        self.f.create_dataset('data', data=self.data, chunks=chunks, **compression)
 
-        with h5py.File(filename, "w") as f:
-            compression = hdf5plugin.Blosc2(cname='lz4', clevel=5, filters=hdf5plugin.Blosc2.SHUFFLE)
-            f.create_dataset('data', data=self.data, chunks=chunks, **compression)
-
-        self.h5file = h5py.File(filename, "r")
-        self.h5dataset = self.h5file["data"]
+        filename = self.f.filename
+        self.f.close()
+        self.f = h5py.File(filename, "r")
+        self.h5dataset = self.f["data"]
 
     def tearDown(self):
         self.h5dataset = None
-        self.h5file.close()
-        self.tempdir.cleanup()
+        super().tearDown()
 
     def testB2Dataset(self):
         b2dataset = B2Dataset(self.h5dataset)
@@ -41,7 +37,7 @@ class TestB2Dataset(TestCase):
         self.assertEqual(b2dataset.chunks, self.h5dataset.chunks)
 
         # Access whole array
-        self.assertTrue(np.array_equal(b2dataset[()], self.data))
+        self.assertArrayEqual(b2dataset[()], self.data)
         # Unoptimized access
-        self.assertTrue(np.array_equal(b2dataset[::2], self.data[::2]))
+        self.assertArrayEqual(b2dataset[::2], self.data[::2])
 

--- a/b2h5py/tests/test_b2dataset.py
+++ b/b2h5py/tests/test_b2dataset.py
@@ -4,7 +4,9 @@
 import numpy as np
 
 from b2h5py import B2Dataset
-from b2h5py.tests.common import StoreArrayMixin
+from b2h5py.tests.common import (Blosc2OptNotUsedError,
+                                 StoreArrayMixin,
+                                 checking_opt_slicing)
 from h5py.tests.common import TestCase
 
 
@@ -25,6 +27,10 @@ class TestB2Dataset(TestCase, StoreArrayMixin):
         self.assertEqual(b2dataset.chunks, self.dset.chunks)
 
         # Access whole array
-        self.assertArrayEqual(b2dataset[()], self.arr)
+        with checking_opt_slicing():
+            self.assertArrayEqual(b2dataset[()], self.arr)
         # Unoptimized access
+        with self.assertRaises(Blosc2OptNotUsedError):
+            with checking_opt_slicing():
+                b2dataset[::2]  # step != 1 not supported currently
         self.assertArrayEqual(b2dataset[::2], self.arr[::2])

--- a/b2h5py/tests/test_b2dataset.py
+++ b/b2h5py/tests/test_b2dataset.py
@@ -1,0 +1,37 @@
+"""Test using B2Dataset to enable fast access to Blosc2 compressed dataset.
+"""
+
+import h5py
+import hdf5plugin
+import numpy as np
+import pytest
+
+from b2h5py import B2Dataset
+
+
+@pytest.fixture
+def hdf5_test_dataset(tmp_path):
+    """Text fixture creating a hdf5 file with a "data" dataset compression with Blosc2"""
+    shape = 3500, 300
+    chunks = 1747, 150
+    data = np.arange(np.prod(shape), dtype="u2").reshape(shape)
+
+    with h5py.File(tmp_path / "test_file.h5", "w") as f:
+        compression = hdf5plugin.Blosc2(cname='lz4', clevel=5, filters=hdf5plugin.Blosc2.SHUFFLE)
+        f.create_dataset('data', data=data, chunks=chunks, **compression)
+
+    with h5py.File(tmp_path / "test_file.h5", "r") as f:
+        yield f["data"]
+
+
+def test_B2Dataset(hdf5_test_dataset):
+    b2dataset = B2Dataset(hdf5_test_dataset)
+    assert b2dataset.is_b2_fast_access
+
+    # Access h5py.Dataset attribute
+    assert b2dataset.chunks == hdf5_test_dataset.chunks
+
+    # Access whole array
+    assert np.array_equal(b2dataset[()], hdf5_test_dataset[()])
+    # Unoptimized access
+    assert np.array_equal(b2dataset[::2], hdf5_test_dataset[::2])

--- a/b2h5py/tests/test_slicing_blosc2.py
+++ b/b2h5py/tests/test_slicing_blosc2.py
@@ -5,54 +5,15 @@ be used.
 """
 
 import os
-import functools
 import random
 
 import b2h5py
-import hdf5plugin as h5p
 import numpy as np
 
-from h5py import File
+from b2h5py.tests.common import (Blosc2OptNotUsedError,
+                                 StoreArrayMixin,
+                                 check_opt_slicing)
 from h5py.tests.common import TestCase
-
-
-class Blosc2OptNotUsedError(Exception):
-    """Blosc2 optimization was not used by unit test"""
-    pass
-
-
-class StoreArrayMixin:
-    # Requires: self.f (read/write), self.arr, self.chunks
-    # Provides: self.f (read-only), self.dset
-    def setUp(self):
-        comp = h5p.Blosc2(cname='lz4', clevel=5, filters=h5p.Blosc2.SHUFFLE)
-        self.f.create_dataset('x', data=self.arr, chunks=self.chunks, **comp)
-
-        # Reopen the test file read-only to ensure
-        # that no HDF5/h5py caching takes place.
-        fn = self.f.filename
-        self.f.close()
-        self.f = File(fn, 'r')
-        self.dset = self.f['x']
-
-
-def check_opt_slicing(test):
-    """Decorate `test` to fail if slicing did not use expected optimization"""
-    @functools.wraps(test)
-    def checked_test(self):
-        if not self.should_enable_opt():
-            return test(self)
-        # If the dataset class is not patched,
-        # the exception set below is never raised anyway.
-        self.assertTrue(b2h5py.is_fast_slicing_enabled())
-        # Force an exception if the optimization is not used.
-        orig_exc = b2h5py.blosc2._no_opt_error
-        b2h5py.blosc2._no_opt_error = Blosc2OptNotUsedError
-        try:
-            return test(self)
-        finally:
-            b2h5py.blosc2._no_opt_error = orig_exc
-    return checked_test
 
 
 class Blosc2OptSlicingTestCase(TestCase, StoreArrayMixin):

--- a/examples/blosc2_optimized_slicing.py
+++ b/examples/blosc2_optimized_slicing.py
@@ -116,3 +116,18 @@ with h5py.File(file_name, 'r') as f:
     assert(not b2h5py.is_fast_slicing_enabled())
     printl("Slice from input array:", data[150:, 150:])
     print()
+
+
+# Use B2Datset wrapper to enable Blosc2 optimized slicing
+# -------------------------------------------------------
+# B2Dataset allows to access a given h5py dataset with optimized slicing.
+from b2h5py import B2Dataset
+
+print("# Using Blosc2 optimized slicing through B2Dataset")
+with h5py.File(file_name, 'r') as f:
+    # Wrap h5py Dataset in B2Dataset
+    dataset = B2Dataset(f[dataset_name])
+    assert dataset.is_b2_fast_access
+    printl("Contiguous slice from dataset (optimized):", dataset[150:, 150:])
+    printl("Contiguous slice from input array:", data[150:, 150:])
+    print()

--- a/examples/blosc2_optimized_slicing.py
+++ b/examples/blosc2_optimized_slicing.py
@@ -127,7 +127,7 @@ print("# Using Blosc2 optimized slicing through B2Dataset")
 with h5py.File(file_name, 'r') as f:
     # Wrap h5py Dataset in B2Dataset
     dataset = B2Dataset(f[dataset_name])
-    assert dataset.is_b2_fast_access
+    assert dataset.is_b2_fast_slicing
     printl("Contiguous slice from dataset (optimized):", dataset[150:, 150:])
     printl("Contiguous slice from input array:", data[150:, 150:])
     print()


### PR DESCRIPTION
This PR propose to add a `B2Dataset` class that can be used to explicitly enable the access optimizations for a given h5py Dataset.

It builds on the same functions as the patching approach.